### PR TITLE
Fix issue#1: avatar image path and layout so avatar displays correctly on all page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ description: a cs and econ major, swiftie, and canadian
 # on the web). Replace "weekly" by the name of your own repository.
 # It should be "USER_NAME-weekly" in which USER_NAME is replaced by your actual
 # user name for GitHub.
+
 avatar: /foxzhang1224-weekly/images/me.png
 # fallback text in case image is not served and/or for screen readers
 avatar_alt_text: Avatar

--- a/index.html
+++ b/index.html
@@ -18,3 +18,4 @@ layout: default
   {% endfor %}
   
 </div>
+


### PR DESCRIPTION
**What did this PR do:**

This PR fixed [issue#1](https://github.com/ossd-s25/foxzhang1224-weekly/issues/1) by changing the media path for my photo to ensure the avatar gets displayed correctly on all sub page.

**Why is it important:**

It's important because otherwise there would only be blank photos on contributions and aboutme page. This PR ensures that the relative media path of myphoto is correct to be used across all subpage.

**What did it change**

in file _config.yml,
we changed avatar media path to avatar: /foxzhang1224-weekly/images/me.png

** Final Presentation **
<img width="1511" alt="Screenshot 2025-05-03 at 11 26 19 AM" src="https://github.com/user-attachments/assets/77efc24f-7567-4f82-9486-86daaf7bcbfb" />
<img width="1507" alt="Screenshot 2025-05-03 at 11 26 14 AM" src="https://github.com/user-attachments/assets/50e0ef83-5609-4b5c-8fa7-57dd7c56f2ef" />
<img width="1510" alt="Screenshot 2025-05-03 at 11 26 09 AM" src="https://github.com/user-attachments/assets/26c74fa5-6995-461c-a624-c27e8cc04583" />
